### PR TITLE
fix: solve issue with client side uploads throwing a FileUploadError when using disablePayloadAccessControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.42.4] - 2025-08-09
+
+### Fixed
+
+- Fixed issue where `clientUploads: true` was not working when `disablePayloadAccessControl: true` was enabled
+
 ## [3.42.3] - 2025-06-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joneslloyd/payload-storage-hetzner",
-  "version": "3.42.3",
+  "version": "3.42.4",
   "description": "Payload storage adapter for Hetzner Object Storage",
   "homepage": "https://github.com/joneslloyd/hetzner-object-storage",
   "repository": {


### PR DESCRIPTION
Commit https://github.com/joneslloyd/hetzner-object-storage/commit/0d4058a340e4553836623b68439a9459565dcc57 broke client-side uploads when using `disablePayloadAccessControl`. 

This PR resolves the issue. More details can be found here: https://github.com/joneslloyd/hetzner-object-storage/issues/1#issuecomment-2970473793

@joneslloyd could you please review, merge, and publish this to npm? Thanks a lot!

For anymore who wants to use this patched version until the npm release is done, add this to your `package.json`:

```
"@joneslloyd/payload-storage-hetzner": "git+https://github.com/jhb-dev/hetzner-object-storage.git#3b64d06e136409df45eb70b9b350aa1649ec7f79",
```